### PR TITLE
Add release build support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 /target
 /vanity-address-generator
 /vanity-address-generator-*
+/.devbox

--- a/Dockerfile.aarch64-unknown-linux-gnu
+++ b/Dockerfile.aarch64-unknown-linux-gnu
@@ -1,0 +1,1 @@
+Dockerfile.x86_64-unknown-linux-gnu

--- a/Dockerfile.x86_64-unknown-linux-gnu
+++ b/Dockerfile.x86_64-unknown-linux-gnu
@@ -1,0 +1,38 @@
+FROM debian:bookworm
+
+# Set DEBIAN_FRONTEND to noninteractive to avoid prompts from apt
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Specify the target platform
+ARG TARGET=x86_64-unknown-linux-gnu
+
+# Workaround for Cloudflare blocking HTTP downloads of package data
+RUN echo "Acquire { https::Verify-Peer false }" >/etc/apt/apt.conf.d/99verify-peer.conf && \
+	sed -i 's/http:/https:/g' /etc/apt/sources.list.d/*.sources && \
+	apt update && \
+	apt install -y ca-certificates && \
+	rm -f /etc/apt/apt.conf.d/99verify-peer.conf && \
+	apt clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Patch the system
+RUN apt update && \
+	apt upgrade -y
+
+# Install dependencies
+RUN apt install -y curl make build-essential
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+	. $HOME/.cargo/env && \
+	rustup default stable && \
+	rustup target add $TARGET
+
+# Compile the project
+COPY . /data
+WORKDIR /data
+
+RUN rm -f Dockerfile*
+
+RUN . $HOME/.cargo/env && \
+	make vanity-address-generator-$TARGET

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,23 @@
+RELEASE_BIN_TARGETS := \
+	x86_64-unknown-linux-gnu \
+	aarch64-unknown-linux-gnu \
+	aarch64-apple-darwin
+
 all: vanity-address-generator
+
+do-release-bin: $(foreach target,$(RELEASE_BIN_TARGETS),target/$(target)/release/vanity-address-generator)
+	for target in $(RELEASE_BIN_TARGETS); do \
+		cp "target/$$target/release/vanity-address-generator" "vanity-address-generator-$$target" || exit 1; \
+	done
+
+target/%/release/vanity-address-generator: src/main.rs
+	if [ -e Dockerfile.$* ]; then \
+		docker build --build-arg 'TARGET=$*' --platform '$(shell echo $* | cut -f 1 -d - | sed 's@x86_64@linux/amd64@;s@aarch64@linux/arm64@')' --tag 'vanity-address-generator-$*' --file 'Dockerfile.$*' '$(shell pwd -P)' &&  \
+		mkdir -p target/$*/release && \
+		docker run --rm --volume "$(shell pwd -P)/target/$*/release:/output" 'vanity-address-generator-$*' cp /data/vanity-address-generator-$* /output/vanity-address-generator; \
+	else \
+		cargo build --target $* --release --bin vanity-address-generator; \
+	fi
 
 target/release/vanity-address-generator: src/main.rs
 	cargo build --release --bin vanity-address-generator
@@ -7,10 +26,15 @@ vanity-address-generator: target/release/vanity-address-generator
 	rm -f '$@'
 	cp '$<' '$@'
 
+vanity-address-generator-%: target/%/release/vanity-address-generator
+	rm -f '$@'
+	cp '$<' '$@'
+
 clean:
 	rm -f vanity-address-generator
+	rm -f vanity-address-generator-*
 	rm -rf target
 
 distclean: clean
 
-.PHONY: all clean distclean
+.PHONY: all do-release-bin clean distclean


### PR DESCRIPTION
This changeset adds support for building release binaries locally -- to migrate to GitHub actions in the future.